### PR TITLE
Fix amd64 restore callback stack pointer

### DIFF
--- a/.github/workflows/buildcommit.yml
+++ b/.github/workflows/buildcommit.yml
@@ -128,7 +128,7 @@ jobs:
         path: lib/${{ matrix.abi }}/libstackman.a
       
   build-windows:
-    runs-on: windows-latest
+    runs-on: windows-2022
     strategy:
       matrix:
         platform: [x86, x64, arm64]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- CI: pinned Windows runner to `windows-2022` (from `windows-latest`) to keep VS2022 v143 toolset availability stable for ARM64 builds
+
 ### Fixed
 - Fixed amd64 (sysv_x86_64 GCC) restore callback stack-pointer argument to pass the active switched stack pointer
 - Added assertion coverage in `tests/test.c` to detect incorrect restore callback stack pointer on amd64

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CI: pinned Windows runner to `windows-2022` (from `windows-latest`) to keep VS2022 v143 toolset availability stable for ARM64 builds
 
 ### Fixed
-- Fixed amd64 (sysv_x86_64 GCC) restore callback stack-pointer argument to pass the active switched stack pointer
+- Fixed amd64 (sysv_amd64 GCC) restore callback stack-pointer argument to pass the active switched stack pointer
 - Added assertion coverage in `tests/test.c` to detect incorrect restore callback stack pointer on amd64
 
 ## [1.2.0] - 2025-11-16
@@ -108,6 +108,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GitHub Actions CI for automated building and testing
 - Visual Studio project files (VS2017, VS2019, VS2022)
 
+[Unreleased]: https://github.com/stackless-dev/stackman/compare/v1.2.0...HEAD
 [1.2.0]: https://github.com/stackless-dev/stackman/releases/tag/v1.2.0
 [1.1.0]: https://github.com/stackless-dev/stackman/releases/tag/v1.1.0
 [1.0.1]: https://github.com/stackless-dev/stackman/releases/tag/v1.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Fixed amd64 (sysv_x86_64 GCC) restore callback stack-pointer argument to pass the active switched stack pointer
+- Added assertion coverage in `tests/test.c` to detect incorrect restore callback stack pointer on amd64
+
 ## [1.2.0] - 2025-11-16
 
 ### Added

--- a/stackman/platforms/switch_x86_64_gcc.S
+++ b/stackman/platforms/switch_x86_64_gcc.S
@@ -93,7 +93,7 @@ LABEL(stackman_switch)
 	addq %rax,  %rbp
 # 0 "" 2
 #NO_APP
-	movq	%rbx, %rdx
+	movq	%rsp, %rdx
 	movl	$1, %esi
 	movq	%r15, %rdi
 	call	*%r14

--- a/stackman/platforms/switch_x86_64_gcc.h
+++ b/stackman/platforms/switch_x86_64_gcc.h
@@ -67,7 +67,7 @@ void *STACKMAN_SWITCH_INASM_NAME(stackman_cb_t callback, void *context)
 	__asm__ ("movq %[result], %%rsp" :: [result] "r" (stack_pointer2));
 	__asm__ ("addq %[arg],  %%rbp" :: [arg] "r" (diff));
 
-	stack_pointer = callback(context, STACKMAN_OP_RESTORE, stack_pointer);
+	stack_pointer = callback(context, STACKMAN_OP_RESTORE, stack_pointer2);
 	/* restore non-volatile registers from stack */
 	__asm__ volatile (
         "ldmxcsr %[sr]\n\t"

--- a/tests/test.c
+++ b/tests/test.c
@@ -102,6 +102,8 @@ void *jmp_cb(void* context, int opcode, void *sp)
 	if (opcode == (int)STACKMAN_OP_SAVE) {
 		return c->stack_near;
 	} else {
+		/* RESTORE must receive the active switched stack pointer. */
+		assert(sp == c->stack_near);
 		restore_stack(c->stack_near, c->buf, c->size);
 		return sp;
 	}


### PR DESCRIPTION
## Summary
- restore sysv_amd64 restore-callback stack pointer fix
- align both assembly and inline GCC x86_64 paths
- add regression assert in tests/test.c for RESTORE stack pointer
- document fix under Unreleased in CHANGELOG

## Validation
- make clean
- make test
- all test suites passed on sysv_amd64