### PR TITLE
Harden ABI detection for cross-build wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.2.2] - 2026-06-05
+### Added
+- Added explicit `STACKMAN_ABI` override support in the Makefile and ABI probe script for deterministic cross-build packaging
 
 ### Changed
-- Windows MSVC library projects now compile with `/Zl` to omit embedded default runtime library directives from generated object files
-- Windows static libraries no longer carry `/DEFAULTLIB:"MSVCRTD"` metadata, reducing unintended CRT coupling for downstream linkers
+- Normalized Windows ARM64 ABI naming to `win_arm64` and kept compatibility mapping for legacy `win_aarch64` inputs
+- ABI probe diagnostics now query compiler target triple and emit clearer mismatch guidance when target intent is not fully propagated through wrapper/toolchain settings
+- Target triple probing now prefers `CC` with `CFLAGS` (with fallback probing) so clang-style cross-target flags are reflected in secondary detection
 
 ## [1.2.1] - 2026-05-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ABI probe diagnostics now query compiler target triple and emit clearer mismatch guidance when target intent is not fully propagated through wrapper/toolchain settings
 - Target triple probing now prefers `CC` with `CFLAGS` (with fallback probing) so clang-style cross-target flags are reflected in secondary detection
 
+## [1.2.2] - 2026-06-05
+
+### Changed
+- Windows MSVC library projects now compile with `/Zl` to omit embedded default runtime library directives from generated object files
+- Windows static libraries no longer carry `/DEFAULTLIB:"MSVCRTD"` metadata, reducing unintended CRT coupling for downstream linkers
+
 ## [1.2.1] - 2026-05-09
 
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,8 @@ endif
 ifeq ($(strip $(STACKMAN_ABI)),)
 ABI := $(shell sh tools/abiname.sh "$(CC)" "$(CFLAGS)")
 else
-ABI := $(STACKMAN_ABI)
+# Accept legacy alias for backward compatibility.
+ABI := $(patsubst win_aarch64,win_arm64,$(STACKMAN_ABI))
 endif
 ifndef ABI
 $(error Could not determine platform)

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ ifeq ($(strip $(STACKMAN_ABI)),)
 ABI := $(shell sh tools/abiname.sh "$(CC)" "$(CFLAGS)")
 else
 # Accept legacy alias for backward compatibility.
-ABI := $(patsubst win_aarch64,win_arm64,$(STACKMAN_ABI))
+ABI := $(patsubst win_aarch64,win_arm64,$(strip $(STACKMAN_ABI)))
 endif
 ifndef ABI
 $(error Could not determine platform)

--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,13 @@ CXX = $(PLATFORM_PREFIX)-g++
 LD = $(PLATFORM_PREFIX)-ld
 AR = $(PLATFORM_PREFIX)-ar
 endif
-# run c preprocessor with any cflags to get cross compilation result, then run regular compile in native
+# Allow explicit ABI selection for deterministic cross-build packaging.
+# If not provided, auto-detect from compiler macros.
+ifeq ($(strip $(STACKMAN_ABI)),)
 ABI := $(shell sh tools/abiname.sh "$(CC)" "$(CFLAGS)")
+else
+ABI := $(STACKMAN_ABI)
+endif
 ifndef ABI
 $(error Could not determine platform)
 endif

--- a/stackman/platforms/platform.h
+++ b/stackman/platforms/platform.h
@@ -44,7 +44,7 @@
 #elif defined(_M_ARM64)
 #include "switch_arm64_msvc.h" /* MS Visual Studio on ARM */
 #define _STACKMAN_PLATFORM arm64_msvc
-#define _STACKMAN_ABI win_aarch64
+#define _STACKMAN_ABI win_arm64
 #endif
 
 

--- a/tools/abiname.sh
+++ b/tools/abiname.sh
@@ -67,15 +67,15 @@ tmp=$(mktemp "${here}/tmp/abinameXXX.c")
 CC=${1:-cc}
 CFLAGS=${2:-}
 ABI_OVERRIDE=${3:-${STACKMAN_ABI:-}}
-target_triple=$(detect_target_triple)
 if [ -n "${ABI_OVERRIDE}" ]; then
 	abi=$(canonicalize_abi "${ABI_OVERRIDE}")
 	if [ -n "${STACKMAN_ABI_DEBUG:-}" ] || [ -n "${STACKMAN_ABI_TRACE:-}" ]; then
-		printf '%s\n' "stackman abiname: cc=${CC} target=${target_triple:-unknown} abi=${abi} source=override" >&2
+		printf '%s\n' "stackman abiname: cc=${CC} target=override-skip abi=${abi} source=override" >&2
 	fi
 	printf '%s\n' "${abi}"
 	exit 0
 fi
+target_triple=$(detect_target_triple)
 ${CC} ${CFLAGS} -I${here}/../stackman -E -o "${tmp}" "${here}/abiname.c"
 #2 compile resulting file
 cc -o "${tmp}.out" "${tmp}"

--- a/tools/abiname.sh
+++ b/tools/abiname.sh
@@ -18,6 +18,11 @@ tmp=$(mktemp "${here}/tmp/abinameXXX.c")
 #1 create the preprocessed file
 CC=${1:-cc}
 CFLAGS=${2:-}
+ABI_OVERRIDE=${3:-${STACKMAN_ABI:-}}
+if [ -n "${ABI_OVERRIDE}" ]; then
+	printf '%s\n' "${ABI_OVERRIDE}"
+	exit 0
+fi
 ${CC} ${CFLAGS} -I${here}/../stackman -E -o "${tmp}" "${here}/abiname.c"
 #2 compile resulting file
 cc -o "${tmp}.out" "${tmp}"

--- a/tools/abiname.sh
+++ b/tools/abiname.sh
@@ -19,6 +19,17 @@ canonicalize_abi() {
 }
 
 detect_target_triple() {
+	# Prefer querying with CFLAGS so explicit target flags (for example
+	# --target=... in clang-based cross builds) are reflected.
+	if ${CC} ${CFLAGS} -dumpmachine >/dev/null 2>&1; then
+		${CC} ${CFLAGS} -dumpmachine
+		return 0
+	fi
+	if ${CC} ${CFLAGS} --print-target-triple >/dev/null 2>&1; then
+		${CC} ${CFLAGS} --print-target-triple
+		return 0
+	fi
+	# Fall back to no CFLAGS in case unrelated build flags make the query fail.
 	if ${CC} -dumpmachine >/dev/null 2>&1; then
 		${CC} -dumpmachine
 		return 0
@@ -73,7 +84,7 @@ abi=$("${tmp}.out")
 abi=$(canonicalize_abi "${abi}")
 target_abi=$(abi_from_target_triple "${target_triple}")
 if [ -n "${target_abi}" ] && [ "${target_abi}" != "${abi}" ]; then
-	printf '%s\n' "warning: stackman ABI mismatch: compiler target '${target_triple}' suggests '${target_abi}', macro probe selected '${abi}'. Consider setting STACKMAN_ABI explicitly." >&2
+	printf '%s\n' "warning: stackman ABI mismatch: compiler target '${target_triple}' suggests '${target_abi}', macro probe selected '${abi}'. This usually means target intent was not fully propagated (flags/wrapper selection). Consider setting STACKMAN_ABI explicitly for deterministic packaging." >&2
 fi
 if [ -n "${STACKMAN_ABI_DEBUG:-}" ] || [ -n "${STACKMAN_ABI_TRACE:-}" ]; then
 	printf '%s\n' "stackman abiname: cc=${CC} target=${target_triple:-unknown} abi=${abi} source=macro" >&2

--- a/tools/abiname.sh
+++ b/tools/abiname.sh
@@ -10,6 +10,14 @@
 # run the provided code.
 set -eu
 here=$(dirname "$0")
+
+canonicalize_abi() {
+	case "$1" in
+		win_aarch64) printf '%s\n' "win_arm64" ;;
+		*) printf '%s\n' "$1" ;;
+	esac
+}
+
 mkdir -p "${here}/tmp"
 # Clean up any stale temp files first
 rm -f "${here}/tmp"/abiname*.c "${here}/tmp"/abiname*.c.out
@@ -20,11 +28,12 @@ CC=${1:-cc}
 CFLAGS=${2:-}
 ABI_OVERRIDE=${3:-${STACKMAN_ABI:-}}
 if [ -n "${ABI_OVERRIDE}" ]; then
-	printf '%s\n' "${ABI_OVERRIDE}"
+	canonicalize_abi "${ABI_OVERRIDE}"
 	exit 0
 fi
 ${CC} ${CFLAGS} -I${here}/../stackman -E -o "${tmp}" "${here}/abiname.c"
 #2 compile resulting file
 cc -o "${tmp}.out" "${tmp}"
 #3 run it
-"${tmp}.out"
+abi=$("${tmp}.out")
+canonicalize_abi "${abi}"

--- a/tools/abiname.sh
+++ b/tools/abiname.sh
@@ -18,6 +18,35 @@ canonicalize_abi() {
 	esac
 }
 
+detect_target_triple() {
+	if ${CC} -dumpmachine >/dev/null 2>&1; then
+		${CC} -dumpmachine
+		return 0
+	fi
+	if ${CC} --print-target-triple >/dev/null 2>&1; then
+		${CC} --print-target-triple
+		return 0
+	fi
+	printf '%s\n' ""
+}
+
+abi_from_target_triple() {
+	triple=$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')
+	case "${triple}" in
+		*x86_64*apple-darwin*|*x86_64*darwin*) printf '%s\n' "darwin_x86_64" ;;
+		*arm64*apple-darwin*|*aarch64*apple-darwin*|*arm64*darwin*|*aarch64*darwin*) printf '%s\n' "darwin_arm64" ;;
+		*x86_64*linux*) printf '%s\n' "sysv_amd64" ;;
+		*i?86*linux*) printf '%s\n' "sysv_i386" ;;
+		*aarch64*linux*) printf '%s\n' "aarch64" ;;
+		*arm*linux*gnueabi*|*armv7*linux*|*armv6*linux*) printf '%s\n' "arm32" ;;
+		*riscv64*linux*) printf '%s\n' "riscv64" ;;
+		*aarch64*w64*mingw*|*arm64*windows*|*aarch64*windows*) printf '%s\n' "win_arm64" ;;
+		*x86_64*w64*mingw*|*x86_64*windows*) printf '%s\n' "win_x64" ;;
+		*i?86*w64*mingw*|*i?86*windows*) printf '%s\n' "win_x86" ;;
+		*) printf '%s\n' "" ;;
+	esac
+}
+
 mkdir -p "${here}/tmp"
 # Clean up any stale temp files first
 rm -f "${here}/tmp"/abiname*.c "${here}/tmp"/abiname*.c.out
@@ -27,8 +56,13 @@ tmp=$(mktemp "${here}/tmp/abinameXXX.c")
 CC=${1:-cc}
 CFLAGS=${2:-}
 ABI_OVERRIDE=${3:-${STACKMAN_ABI:-}}
+target_triple=$(detect_target_triple)
 if [ -n "${ABI_OVERRIDE}" ]; then
-	canonicalize_abi "${ABI_OVERRIDE}"
+	abi=$(canonicalize_abi "${ABI_OVERRIDE}")
+	if [ -n "${STACKMAN_ABI_DEBUG:-}" ] || [ -n "${STACKMAN_ABI_TRACE:-}" ]; then
+		printf '%s\n' "stackman abiname: cc=${CC} target=${target_triple:-unknown} abi=${abi} source=override" >&2
+	fi
+	printf '%s\n' "${abi}"
 	exit 0
 fi
 ${CC} ${CFLAGS} -I${here}/../stackman -E -o "${tmp}" "${here}/abiname.c"
@@ -36,4 +70,12 @@ ${CC} ${CFLAGS} -I${here}/../stackman -E -o "${tmp}" "${here}/abiname.c"
 cc -o "${tmp}.out" "${tmp}"
 #3 run it
 abi=$("${tmp}.out")
-canonicalize_abi "${abi}"
+abi=$(canonicalize_abi "${abi}")
+target_abi=$(abi_from_target_triple "${target_triple}")
+if [ -n "${target_abi}" ] && [ "${target_abi}" != "${abi}" ]; then
+	printf '%s\n' "warning: stackman ABI mismatch: compiler target '${target_triple}' suggests '${target_abi}', macro probe selected '${abi}'. Consider setting STACKMAN_ABI explicitly." >&2
+fi
+if [ -n "${STACKMAN_ABI_DEBUG:-}" ] || [ -n "${STACKMAN_ABI_TRACE:-}" ]; then
+	printf '%s\n' "stackman abiname: cc=${CC} target=${target_triple:-unknown} abi=${abi} source=macro" >&2
+fi
+printf '%s\n' "${abi}"


### PR DESCRIPTION
## Summary\n- add explicit STACKMAN_ABI override path for deterministic ABI selection\n- normalize Windows ARM64 ABI token to win_arm64 while preserving win_aarch64 compatibility alias\n- add compiler target-triple diagnostics and mismatch warnings in ABI probe\n- query target triple with CC+CFLAGS (with fallback) so clang cross-target flags are reflected\n- document these changes under Unreleased in CHANGELOG\n\n## Validation\n- make abiname\n- STACKMAN_ABI_DEBUG=1 make abiname\n- STACKMAN_ABI=win_aarch64 make abiname\n- make test (previously run on branch)\n\n## Notes\n- existing local generated artifact and analysis note file were intentionally not included in commits