### PR TITLE
CI: build and test on FreeBSD, OpenBSD and NetBSD

### DIFF
--- a/.github/workflows/buildbsd.yml
+++ b/.github/workflows/buildbsd.yml
@@ -1,0 +1,64 @@
+name: build and test bsd
+
+on:
+  push:
+    branches: [ master, dev ]
+
+  pull_request:
+    branches: [ master ]
+
+# The BSDs use the same sysv_amd64 ABI as Linux, so these jobs build and test
+# the existing sources rather than producing an additional library artifact.
+# Each job runs in a real VM on the ubuntu-latest runner; GNU make is required
+# because the Makefile uses GNU make syntax, while the BSD base system make
+# is bmake.
+
+jobs:
+
+  build-freebsd:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6.0.2
+    - name: build and test
+      uses: vmactions/freebsd-vm@v1
+      with:
+        usesh: true
+        cache-after-prepare: true
+        prepare: |
+          pkg install -y gmake
+        run: |
+          set -ex
+          gmake all
+          gmake test
+
+  build-openbsd:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6.0.2
+    - name: build and test
+      uses: vmactions/openbsd-vm@v1
+      with:
+        usesh: true
+        cache-after-prepare: true
+        prepare: |
+          pkg_add -I gmake
+        run: |
+          set -ex
+          gmake all
+          gmake test
+
+  build-netbsd:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6.0.2
+    - name: build and test
+      uses: vmactions/netbsd-vm@v1
+      with:
+        usesh: true
+        cache-after-prepare: true
+        prepare: |
+          /usr/sbin/pkg_add gmake
+        run: |
+          set -ex
+          gmake all
+          gmake test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- ABI detection now works on the BSDs: `tools/abiname.sh` used a `mktemp` template with three `X`s, which BSD `mktemp(1)` rejects.
+
 ## [1.2.5] - 2026-06-23
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- FreeBSD, OpenBSD and NetBSD (amd64, `sysv_amd64` ABI) are built and tested on every commit by a new `build and test bsd` workflow.
+
 ### Fixed
 - ABI detection now works on the BSDs: `tools/abiname.sh` used a `mktemp` template with three `X`s, which BSD `mktemp(1)` rejects.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![build test and commit](https://github.com/stackless-dev/stackman/actions/workflows/buildcommit.yml/badge.svg)](https://github.com/stackless-dev/stackman/actions/workflows/buildcommit.yml)
+[![build and test bsd](https://github.com/stackless-dev/stackman/actions/workflows/buildbsd.yml/badge.svg)](https://github.com/stackless-dev/stackman/actions/workflows/buildbsd.yml)
 
 
 ```
@@ -101,8 +102,15 @@ calling convention, plus archive format:
    - win_x86 (32-bit)
    - win_x64 (64-bit)
    - win_arm64 (64-bit ARM)
+ - **FreeBSD, OpenBSD, NetBSD (System V ABI)**
+   - sysv_amd64 (64-bit x86_64)
 
 All platforms are automatically built and tested by GitHub Actions CI on every commit.
+
+The BSDs share the `sysv_amd64` ABI with Linux and therefore need no separate
+assembly implementation or pre-built library; they are built and tested from
+source by the `build and test bsd` workflow.  Note that the Makefile requires
+GNU make, which on the BSDs is `gmake` rather than the base system `make`.
 
 ### Supported toolchains:
 

--- a/tools/abiname.sh
+++ b/tools/abiname.sh
@@ -61,7 +61,8 @@ abi_from_target_triple() {
 mkdir -p "${here}/tmp"
 # Clean up any stale temp files first
 rm -f "${here}/tmp"/abiname*.c "${here}/tmp"/abiname*.c.out
-tmp=$(mktemp "${here}/tmp/abinameXXX.c")
+# BSD mktemp(1) requires at least six trailing Xs; GNU mktemp accepts them too.
+tmp=$(mktemp "${here}/tmp/abinameXXXXXX.c")
 
 #1 create the preprocessed file
 CC=${1:-cc}


### PR DESCRIPTION
Closes #15

The issue anticipated new assembly, a `platform.h` branch and possible OpenBSD `W^X` trouble. In practice none of that was needed -- the three BSDs on amd64 already resolve to the existing `sysv_amd64` ABI, and the ELF paths in the assembly sources apply unchanged. Only one real portability bug stood in the way.

### What changed

**1. `tools/abiname.sh` -- ABI detection was broken on the BSDs**

The temp file was created with a three-`X` `mktemp` template. GNU `mktemp` accepts that; BSD `mktemp(1)` requires at least six and fails:

```
mktemp: insufficient number of Xs in template `tools/tmp/abinameXXX.c'
Makefile:29: *** Could not determine platform.  Stop.
```

Changed to a six-`X` template, which is valid for both. This is the only source change, and it is what the BSD jobs could not be green without.

**2. New `.github/workflows/buildbsd.yml`**

A separate workflow, so `buildcommit.yml` is untouched. Three jobs running in real VMs via `vmactions/*-vm` on `ubuntu-latest`; `gmake` is installed in `prepare` because the Makefile is GNU-make syntax while the BSD base `make` is bmake.

The jobs do **not** upload a library artifact: the ABI is `sysv_amd64`, identical to the Linux job's, so an artifact would only duplicate it (and collide on the artifact name).

**3. README / CHANGELOG** -- platform list, a badge for the new workflow, changelog entries.

### CI evidence

Both runs are on the exact head commit of this PR (`8febe73`):

- BSD workflow -- all three green: https://github.com/neilpang/stackman/actions/runs/30357368568
- Pre-existing workflow, unchanged, re-run as a regression check on the `abiname.sh` edit -- all 10 jobs green (Linux x5, macOS x2, Windows x3): https://github.com/neilpang/stackman/actions/runs/30357371214

What the BSD logs actually show:

| | version | compiler | `make abiname` | tests |
|---|---|---|---|---|
| FreeBSD | 15.1-RELEASE-p1 amd64 | clang 19.1.7 | `sysv_amd64` | `test_01`-`test_08` + `test_cc`, `*** All test suites passed ***` |
| OpenBSD | 7.9 amd64 | clang 19.1.7 | `sysv_amd64` | same |
| NetBSD | 10.1 amd64 | base gcc | `sysv_amd64` | same, **plus** the full suite again under `test_static`/`test_asm` |

NetBSD is worth noting: because its base compiler is gcc rather than clang, `test_static` compiles the inline-assembly path instead of printing `no static with external asm`, so it exercises inline asm on a BSD -- coverage the clang-based BSDs and macOS do not give.

### Points for you to decide

- **OpenBSD `W^X`:** the concern in the issue did not materialize. Worth being precise about why, rather than reading too much into the green check: `stackman` does not generate code at runtime, so `W^X` is not implicated at all. The relevant OpenBSD mechanism is `MAP_STACK`, and the test suite switches onto `malloc`'d stacks without making syscalls while switched, so it passes. A consumer that *does* syscall on a non-`MAP_STACK` stack could still be killed by the kernel. This PR proves the library builds and its tests pass; it is not a general guarantee for OpenBSD consumers.
- **OS versions are not pinned.** `vmactions/*-vm@v1` boots each project's current release (today: 15.1 / 7.9 / 10.1). That tracks upstream automatically but means a future BSD release could break the job without a commit here. Say the word if you would rather pin `release:` per job.
- **amd64 only.** aarch64 images exist for all three; I kept the matrix to what the issue asked for. Easy to add if you want it.
